### PR TITLE
patch to prevent compilation error, examples now compile using arduioo 1...

### DIFF
--- a/Arduino/libraries/RBL_nRF8001/RBL_nRF8001.cpp
+++ b/Arduino/libraries/RBL_nRF8001/RBL_nRF8001.cpp
@@ -22,7 +22,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #endif
 
 /* Store the setup for the nRF8001 in the flash of the AVR to save on RAM */
-static hal_aci_data_t setup_msgs[NB_SETUP_MESSAGES] PROGMEM = SETUP_MESSAGES_CONTENT;
+static const hal_aci_data_t setup_msgs[NB_SETUP_MESSAGES] PROGMEM = SETUP_MESSAGES_CONTENT;
 
 #if defined(BLEND_MICRO)
 static char device_name[11] = "BlendMicro";
@@ -110,7 +110,7 @@ void ble_begin()
         aci_state.aci_setup_info.services_pipe_type_mapping = NULL;
     }
     aci_state.aci_setup_info.number_of_pipes    = NUMBER_OF_PIPES;
-    aci_state.aci_setup_info.setup_msgs         = setup_msgs;
+    aci_state.aci_setup_info.setup_msgs         = (hal_aci_data_t*)setup_msgs;
     aci_state.aci_setup_info.num_setup_msgs     = NB_SETUP_MESSAGES;
 
     /*


### PR DESCRIPTION
...:1.0.5+dfsg2-2 (which is the version in the ubuntu and debian repositories).

Note: this bug has already been documented in various places:
- RedBearLab/BLEShield#5
- https://redbearlab.zendesk.com/entries/23440476-Getting-Started
- http://www.avrfreaks.net/index.php?name=PNphpBB2&file=viewtopic&t=38003

find . -name "_.ino" -print | xargs subl
find . -name "_.cpp" -print | xargs subl

find:
static hal_aci_data_t setup_msgs[NB_SETUP_MESSAGES] PROGMEM

replace:
static const hal_aci_data_t setup_msgs[NB_SETUP_MESSAGES] PROGMEM

find:
aci_state.aci_setup_info.setup_msgs = setup_msgs;

replace:
aci_state.aci_setup_info.setup_msgs = (hal_aci_data_t*)setup_msgs;
